### PR TITLE
確認画面と完了画面のレイアウト修正

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -196,10 +196,12 @@ fieldset {
   background-color: var(--custom-gray-500);
   border-color: var(--custom-gray-500);
   color: white;
-  padding: 0.75rem 2rem;
+  padding: 1rem 2.5rem;
+  font-size: 1.1rem;
   font-weight: var(--custom-font-weight-medium);
   border-radius: var(--custom-border-radius-pill);
   transition: var(--custom-transition);
+  min-width: 200px;
 }
 
 .btn-custom-secondary:hover {
@@ -226,6 +228,19 @@ fieldset {
 }
 
 /* 確認画面用のスタイル */
+.confirm-value {
+  background-color: var(--custom-gray-100);
+  padding: 0.75rem;
+  border-radius: var(--custom-border-radius);
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  border: 2px solid var(--custom-gray-300);
+  min-height: 2.5rem;
+  display: block;
+  text-align: left;
+}
+
+/* 旧スタイルは削除 */
 .confirm-card {
   background-color: white;
   border: 1px solid var(--custom-gray-300);
@@ -249,14 +264,6 @@ fieldset {
   font-weight: var(--custom-font-weight-bold);
   color: var(--custom-gray-800);
   margin-bottom: 0.5rem;
-}
-
-.confirm-value {
-  background-color: var(--custom-gray-100);
-  padding: 0.75rem;
-  border-radius: var(--custom-border-radius);
-  white-space: pre-wrap;
-  word-wrap: break-word;
 }
 
 /* 成功メッセージ */
@@ -284,13 +291,20 @@ fieldset {
     font-size: 1rem;
   }
 
-  .btn-custom-secondary,
+  .btn-custom-secondary {
+    width: 100%;
+    min-width: auto;
+    padding: 1rem;
+    font-size: 1rem;
+    margin-bottom: 0.5rem;
+  }
+
   .btn-custom-success {
     width: 100%;
     margin-bottom: 0.5rem;
   }
 
-  fieldset.border {
+  fieldset {
     padding: 1rem;
   }
 }

--- a/view/complete.php
+++ b/view/complete.php
@@ -46,7 +46,7 @@
                 <!-- 戻るボタン -->
                 <div class="text-center">
                     <a href="index.php?action=input" class="btn custom-btn">
-                        <i class="bi bi-arrow-left me-2"></i>入力画面に戻る
+                        入力画面に戻る
                     </a>
                 </div>
             </div>

--- a/view/confirm.php
+++ b/view/confirm.php
@@ -45,69 +45,85 @@
     <div class="container mb-5">
         <div class="row justify-content-center">
             <div class="col-lg-8 col-md-10">
-                <div class="confirm-card">
+                <div class="bg-white rounded-3 shadow-sm p-4">
                     <h2 class="h4 mb-4 text-center text-dark fw-bold">入力内容の確認</h2>
                     
-                    <div class="confirm-item">
-                        <div class="confirm-label">氏名</div>
-                        <div class="confirm-value"><?php echo htmlspecialchars($_SESSION['form_data']['name'], ENT_QUOTES); ?></div>
-                    </div>
-                    
-                    <div class="confirm-item">
-                        <div class="confirm-label">メールアドレス</div>
-                        <div class="confirm-value"><?php echo htmlspecialchars($_SESSION['form_data']['email'], ENT_QUOTES); ?></div>
-                    </div>
-                    
-                    <div class="confirm-item">
-                        <div class="confirm-label">サービス</div>
-                        <div class="confirm-value">
-                            <?php 
-                            echo htmlspecialchars($serviceLabels[$_SESSION['form_data']['service']] ?? $_SESSION['form_data']['service'], ENT_QUOTES); 
-                            ?>
+                    <!-- 氏名 -->
+                    <div class="row mb-4">
+                        <label class="col-sm-3 col-form-label">
+                            氏名 <span class="required-label">必須</span>
+                        </label>
+                        <div class="col-sm-9">
+                            <div class="confirm-value"><?php echo htmlspecialchars($_SESSION['form_data']['name'], ENT_QUOTES); ?></div>
                         </div>
                     </div>
                     
-                    <div class="confirm-item">
-                        <div class="confirm-label">カテゴリー</div>
-                        <div class="confirm-value">
-                            <?php 
-                            echo htmlspecialchars($categoryLabels[$_SESSION['form_data']['category']] ?? $_SESSION['form_data']['category'], ENT_QUOTES); 
-                            ?>
+                    <!-- メールアドレス -->
+                    <div class="row mb-4">
+                        <label class="col-sm-3 col-form-label">
+                            メールアドレス <span class="required-label">必須</span>
+                        </label>
+                        <div class="col-sm-9">
+                            <div class="confirm-value"><?php echo htmlspecialchars($_SESSION['form_data']['email'], ENT_QUOTES); ?></div>
                         </div>
                     </div>
                     
+                    <!-- サービス -->
+                    <div class="row mb-4">
+                        <label class="col-sm-3 col-form-label">
+                            サービス <span class="required-label">必須</span>
+                        </label>
+                        <div class="col-sm-9">
+                            <div class="confirm-value"><?php echo htmlspecialchars($serviceLabels[$_SESSION['form_data']['service']] ?? $_SESSION['form_data']['service'], ENT_QUOTES); ?></div>
+                        </div>
+                    </div>
+                    
+                    <!-- カテゴリー -->
+                    <div class="row mb-4">
+                        <label class="col-sm-3 col-form-label">
+                            カテゴリー <span class="required-label">必須</span>
+                        </label>
+                        <div class="col-sm-9">
+                            <div class="confirm-value"><?php echo htmlspecialchars($categoryLabels[$_SESSION['form_data']['category']] ?? $_SESSION['form_data']['category'], ENT_QUOTES); ?></div>
+                        </div>
+                    </div>
+                    
+                    <!-- プラン -->
                     <?php if (!empty($_SESSION['form_data']['plan'])): ?>
-                    <div class="confirm-item">
-                        <div class="confirm-label">プラン</div>
-                        <div class="confirm-value">
-                            <?php 
-                            $selectedPlans = [];
-                            foreach ($_SESSION['form_data']['plan'] as $plan) {
-                                $selectedPlans[] = $planLabels[$plan] ?? $plan;
-                            }
-                            echo htmlspecialchars(implode('・', $selectedPlans), ENT_QUOTES); 
-                            ?>
+                    <div class="row mb-4">
+                        <label class="col-sm-3 col-form-label">プラン</label>
+                        <div class="col-sm-9">
+                            <div class="confirm-value"><?php $selectedPlans = []; foreach ($_SESSION['form_data']['plan'] as $plan) { $selectedPlans[] = $planLabels[$plan] ?? $plan; } echo htmlspecialchars(implode('・', $selectedPlans), ENT_QUOTES); ?></div>
                         </div>
                     </div>
                     <?php endif; ?>
                     
-                    <div class="confirm-item">
-                        <div class="confirm-label">お問い合わせ内容</div>
-                        <div class="confirm-value"><?php echo htmlspecialchars($_SESSION['form_data']['message'], ENT_QUOTES); ?></div>
+                    <!-- お問い合わせ内容 -->
+                    <div class="row mb-5">
+                        <label class="col-sm-3 col-form-label">
+                            お問い合わせ内容 <span class="required-label">必須</span>
+                        </label>
+                        <div class="col-sm-9">
+                            <div class="confirm-value"><?php echo htmlspecialchars($_SESSION['form_data']['message'], ENT_QUOTES); ?></div>
+                        </div>
                     </div>
-                </div>
-                
-                <!-- ボタングループ -->
-                <div class="d-flex flex-column flex-md-row justify-content-center gap-3 mt-4">
-                    <a href="index.php?action=input" class="btn btn-custom-secondary">
-                        <i class="bi bi-arrow-left me-2"></i>入力画面に戻る
-                    </a>
                     
-                    <form action="index.php?action=complete" method="POST" class="d-inline">
-                        <button type="submit" class="btn btn-custom-success">
-                            <i class="bi bi-send me-2"></i>送信する
-                        </button>
-                    </form>
+                    <!-- ボタングループ -->
+                    <div class="row">
+                        <div class="col-sm-9 offset-sm-3">
+                            <div class="d-flex flex-column flex-md-row justify-content-center gap-3">
+                                <a href="index.php?action=input" class="btn btn-custom-secondary">
+                                    入力画面に戻る
+                                </a>
+                                
+                                <form action="index.php?action=complete" method="POST" class="d-inline">
+                                    <button type="submit" class="btn custom-btn">
+                                        送信する
+                                    </button>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
fix #3 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- スタイル
  - 確認画面をグリッドレイアウトに刷新し、ラベル左・値右で視認性を向上。必須表示を追加。
  - ボタン/フィールドのサイズ・余白・フォントを拡大し、タップしやすさと可読性を改善。
  - 確認値の表示ボックスを新調し、読みやすさを向上。
  - 戻る/送信ボタンのアイコンを削除してシンプルな見た目に。

- バグ修正
  - スマホ向けスタイルの指定ミスを修正し、横幅・余白・フォントの挙動を適正化。
  - レスポンシブ時のフィールドセット余白調整を適用。

- リファクタリング
  - 画面構成を整理し、各項目を行単位で整列。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->